### PR TITLE
perf: improve bytes deserialization performance 2~3x

### DIFF
--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -50,7 +50,7 @@ fn bytes(c: &mut Criterion) {
 fn read_bytes(c: &mut Criterion) {
     let mut group = c.benchmark_group("read_bytes");
 
-    for size in [10, 100, 1000] {
+    for size in [10, 20, 50] {
         let bytes = (0..size).map(|_| rand::random::<u8>()).collect::<Vec<_>>();
 
         // Serialize bytes to create test data

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use memcomparable::Serializer;
+use memcomparable::{Deserializer, Serializer};
 use serde::Serializer as _;
 
-criterion_group!(benches, decimal, bytes);
+criterion_group!(benches, decimal, bytes, read_bytes);
 criterion_main!(benches);
 
 #[cfg(not(feature = "decimal"))]
@@ -41,6 +41,41 @@ fn bytes(c: &mut Criterion) {
                 s.set_reverse(true);
                 s.serialize_bytes(&bytes).unwrap();
                 black_box(s);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn read_bytes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("read_bytes");
+
+    for size in [10, 100, 1000] {
+        let bytes = (0..size).map(|_| rand::random::<u8>()).collect::<Vec<_>>();
+
+        // Serialize bytes to create test data
+        let mut ser = Serializer::new(Vec::with_capacity(size / 8 * 9));
+        ser.serialize_bytes(&bytes).unwrap();
+        let encoded = ser.into_inner();
+
+        group.bench_function(format!("size-{}", size), |b| {
+            b.iter(|| {
+                let mut de = Deserializer::new(black_box(encoded.as_slice()));
+                black_box(de.read_bytes().unwrap());
+            });
+        });
+
+        // Test with reverse encoding
+        let mut ser = Serializer::new(Vec::with_capacity(size / 8 * 9));
+        ser.set_reverse(true);
+        ser.serialize_bytes(&bytes).unwrap();
+        let encoded_reverse = ser.into_inner();
+
+        group.bench_function(format!("size-{}-reverse", size), |b| {
+            b.iter(|| {
+                let mut de = Deserializer::new(black_box(encoded_reverse.as_slice()));
+                de.set_reverse(true);
+                black_box(de.read_bytes().unwrap());
             });
         });
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -125,7 +125,17 @@ impl<B: Buf> MaybeFlip<B> {
 }
 
 impl<B: Buf> Deserializer<B> {
-    fn read_bytes(&mut self) -> Result<Vec<u8>> {
+    /// Read a byte array from the deserializer.
+    ///
+    /// This method deserializes a byte array that was previously serialized
+    /// using the memcomparable format. It handles both empty and non-empty
+    /// byte arrays, and respects the reverse encoding flag if set.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Vec<u8>)` containing the deserialized bytes, or an error
+    /// if the encoding is invalid.
+    pub fn read_bytes(&mut self) -> Result<Vec<u8>> {
         match self.input.get_u8() {
             0 => return Ok(vec![]), // empty slice
             1 => {}                 // non-empty slice

--- a/src/de.rs
+++ b/src/de.rs
@@ -125,17 +125,11 @@ impl<B: Buf> MaybeFlip<B> {
 }
 
 impl<B: Buf> Deserializer<B> {
-    /// Read a byte array from the deserializer.
-    ///
-    /// This method deserializes a byte array that was previously serialized
-    /// using the memcomparable format. It handles both empty and non-empty
-    /// byte arrays, and respects the reverse encoding flag if set.
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok(Vec<u8>)` containing the deserialized bytes, or an error
-    /// if the encoding is invalid.
+    /// Read bytes entry
     pub fn read_bytes(&mut self) -> Result<Vec<u8>> {
+        if !self.input.flip {
+            return self.read_bytes_fast();
+        }
         match self.input.get_u8() {
             0 => return Ok(vec![]), // empty slice
             1 => {}                 // non-empty slice
@@ -151,6 +145,100 @@ impl<B: Buf> Deserializer<B> {
                     return Ok(bytes);
                 }
                 9 => bytes.extend_from_slice(&chunk[..8]),
+                v => return Err(Error::InvalidBytesEncoding(v)),
+            }
+        }
+    }
+
+    /// Fast implementation for reading bytes from memcomparable format with the premise that
+    /// most bytes fit into one cache line.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Vec<u8>)` - The deserialized byte array
+    /// - `Err(Error::Eof)` - If there's not enough data in the buffer
+    /// - `Err(Error::InvalidBytesEncoding)` - If the encoding is invalid
+    ///
+    fn read_bytes_fast(&mut self) -> Result<Vec<u8>> {
+        match self.input.get_u8() {
+            0 => return Ok(vec![]), // empty slice
+            1 => {}                 // non-empty slice
+            v => return Err(Error::InvalidBytesEncoding(v)),
+        }
+
+        const MAX_CACHE_CHUNKS: usize = 7;
+        const INDICATOR_OFFSETS: [usize; MAX_CACHE_CHUNKS] = [8, 17, 26, 35, 44, 53, 62];
+
+        let input = self.input.input.chunk();
+        let mut res = Vec::new();
+        let mut chunks_processed = 0;
+
+        // Process first chunks using cache-friendly access
+        for (chunk_idx, &indicator_offset) in INDICATOR_OFFSETS.iter().enumerate() {
+            if input.len() <= indicator_offset {
+                return Err(Error::Eof);
+            }
+
+            let indicator = input[indicator_offset];
+            let chunk_data_start = chunk_idx * BYTES_CHUNK_UNIT_SIZE;
+
+            match indicator {
+                len @ 1..=8 => {
+                    if len == 0 || len > 9 {
+                        return Err(Error::InvalidBytesEncoding(len));
+                    }
+                    if res.is_empty() {
+                        res = input[chunk_data_start..(chunk_data_start + len as usize)].to_vec();
+                    } else {
+                        res.extend_from_slice(
+                            &input[chunk_data_start..(chunk_data_start + len as usize)],
+                        );
+                    }
+                    self.input
+                        .input
+                        .advance((chunk_idx + 1) * BYTES_CHUNK_UNIT_SIZE);
+                    return Ok(res);
+                }
+                9 => {
+                    // Full chunk, accumulate and continue reading
+                    if res.is_empty() {
+                        res = Vec::with_capacity(64);
+                    }
+                    res.extend_from_slice(
+                        &input[chunk_data_start..(chunk_data_start + BYTES_CHUNK_SIZE)],
+                    );
+                    chunks_processed += 1;
+                }
+                v => return Err(Error::InvalidBytesEncoding(v)),
+            }
+        }
+
+        // Advance past the cached chunks
+        if chunks_processed > 0 {
+            self.input
+                .input
+                .advance(chunks_processed * BYTES_CHUNK_UNIT_SIZE);
+        }
+
+        // Continue reading chunks until we find a non-9 indicator
+        let mut chunk = [0u8; BYTES_CHUNK_UNIT_SIZE];
+        loop {
+            // Read next chunk
+            if self.input.input.remaining() < BYTES_CHUNK_UNIT_SIZE {
+                return Err(Error::Eof);
+            }
+            self.input.input.copy_to_slice(&mut chunk);
+            match chunk[8] {
+                len @ 1..=8 => {
+                    res.extend_from_slice(&chunk[..len as usize]);
+                    if self.input.flip {
+                        res.iter_mut().for_each(|x| *x = !*x);
+                    }
+                    return Ok(res);
+                }
+                9 => {
+                    res.extend_from_slice(&chunk[..8]);
+                }
                 v => return Err(Error::InvalidBytesEncoding(v)),
             }
         }
@@ -478,20 +566,6 @@ impl<'de, 'a, B: Buf + 'de> de::Deserializer<'de> for &'a mut Deserializer<B> {
     where
         V: Visitor<'de>,
     {
-        impl<'de, 'a, B: Buf + 'de> EnumAccess<'de> for &'a mut Deserializer<B> {
-            type Error = Error;
-            type Variant = Self;
-
-            fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
-            where
-                V: DeserializeSeed<'de>,
-            {
-                let idx = self.input.get_u8() as u32;
-                let val: Result<_> = seed.deserialize(idx.into_deserializer());
-                Ok((val?, self))
-            }
-        }
-
         visitor.visit_enum(self)
     }
 
@@ -538,6 +612,20 @@ impl<'de, 'a, B: Buf + 'de> VariantAccess<'de> for &'a mut Deserializer<B> {
         V: Visitor<'de>,
     {
         serde::de::Deserializer::deserialize_tuple(self, fields.len(), visitor)
+    }
+}
+
+impl<'de, 'a, B: Buf + 'de> EnumAccess<'de> for &'a mut Deserializer<B> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let idx = self.input.get_u8() as u32;
+        let val: Result<_> = seed.deserialize(idx.into_deserializer());
+        Ok((val?, self))
     }
 }
 
@@ -610,9 +698,10 @@ impl<B: Buf> Deserializer<B> {
 
 #[cfg(test)]
 mod tests {
-    use serde::Deserialize;
-
     use super::*;
+    use crate::{Deserializer, Serializer};
+    use bytes::Bytes;
+    use serde::{Deserialize, Serializer as _};
 
     #[test]
     fn test_unit() {
@@ -763,6 +852,17 @@ mod tests {
             from_slice::<String>(&[2]),
             Err(Error::InvalidBytesEncoding(2))
         );
+    }
+
+    #[test]
+    fn test_long_string() {
+        let s = "a".repeat(100);
+        let mut serializer = Serializer::new(vec![]);
+        serializer.serialize_str(&s).unwrap();
+        let mut bytes = Bytes::from(serializer.into_inner());
+        let mut deserializer = Deserializer::new(&mut bytes);
+        let string = String::deserialize(&mut deserializer).unwrap();
+        assert_eq!(string, s);
     }
 
     #[test]

--- a/src/de.rs
+++ b/src/de.rs
@@ -111,14 +111,6 @@ impl<B: Buf> MaybeFlip<B> {
 
     def_method!(get_u128, u128);
 
-    fn copy_to_slice(&mut self, dst: &mut [u8]) -> Result<()> {
-        self.input.try_copy_to_slice(dst).map_err(|_| Error::Eof)?;
-        if self.flip {
-            dst.iter_mut().for_each(|x| *x = !*x);
-        }
-        Ok(())
-    }
-
     fn is_empty(&self) -> bool {
         self.input.remaining() == 0
     }
@@ -127,48 +119,15 @@ impl<B: Buf> MaybeFlip<B> {
 impl<B: Buf> Deserializer<B> {
     /// Read bytes entry
     pub fn read_bytes(&mut self) -> Result<Vec<u8>> {
-        if !self.input.flip {
-            return self.read_bytes_fast();
-        }
-        match self.input.get_u8() {
-            0 => return Ok(vec![]), // empty slice
-            1 => {}                 // non-empty slice
-            v => return Err(Error::InvalidBytesEncoding(v)),
-        }
-        let mut bytes = vec![];
-        let mut chunk = [0u8; BYTES_CHUNK_UNIT_SIZE]; // chunk + chunk_len
-        loop {
-            self.input.copy_to_slice(&mut chunk)?;
-            match chunk[8] {
-                len @ 1..=8 => {
-                    bytes.extend_from_slice(&chunk[..len as usize]);
-                    return Ok(bytes);
-                }
-                9 => bytes.extend_from_slice(&chunk[..8]),
-                v => return Err(Error::InvalidBytesEncoding(v)),
-            }
-        }
-    }
-
-    /// Fast implementation for reading bytes from memcomparable format with the premise that
-    /// most bytes fit into one cache line.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(Vec<u8>)` - The deserialized byte array
-    /// - `Err(Error::Eof)` - If there's not enough data in the buffer
-    /// - `Err(Error::InvalidBytesEncoding)` - If the encoding is invalid
-    ///
-    fn read_bytes_fast(&mut self) -> Result<Vec<u8>> {
         match self.input.get_u8() {
             0 => return Ok(vec![]), // empty slice
             1 => {}                 // non-empty slice
             v => return Err(Error::InvalidBytesEncoding(v)),
         }
 
-        const MAX_CACHE_CHUNKS: usize = 7;
-        const INDICATOR_OFFSETS: [usize; MAX_CACHE_CHUNKS] = [8, 17, 26, 35, 44, 53, 62];
+        const INDICATOR_OFFSETS: [usize; 7] = [8, 17, 26, 35, 44, 53, 62];
 
+        let flip = self.input.flip;
         let input = self.input.input.chunk();
         let mut res = Vec::new();
         let mut chunks_processed = 0;
@@ -179,7 +138,12 @@ impl<B: Buf> Deserializer<B> {
                 return Err(Error::Eof);
             }
 
-            let indicator = input[indicator_offset];
+            // Read indicator byte, flipping if needed
+            let indicator = if flip {
+                !input[indicator_offset]
+            } else {
+                input[indicator_offset]
+            };
             let chunk_data_start = chunk_idx * BYTES_CHUNK_UNIT_SIZE;
 
             match indicator {
@@ -197,6 +161,10 @@ impl<B: Buf> Deserializer<B> {
                     self.input
                         .input
                         .advance((chunk_idx + 1) * BYTES_CHUNK_UNIT_SIZE);
+                    // Flip all accumulated bits in bulk if needed
+                    if flip {
+                        res.iter_mut().for_each(|x| *x = !*x);
+                    }
                     return Ok(res);
                 }
                 9 => {
@@ -228,10 +196,13 @@ impl<B: Buf> Deserializer<B> {
                 return Err(Error::Eof);
             }
             self.input.input.copy_to_slice(&mut chunk);
-            match chunk[8] {
+            // Read indicator byte, flipping if needed
+            let indicator = if flip { !chunk[8] } else { chunk[8] };
+            match indicator {
                 len @ 1..=8 => {
                     res.extend_from_slice(&chunk[..len as usize]);
-                    if self.input.flip {
+                    // Flip all accumulated bits in bulk if needed
+                    if flip {
                         res.iter_mut().for_each(|x| *x = !*x);
                     }
                     return Ok(res);
@@ -266,7 +237,7 @@ impl<B: Buf> Deserializer<B> {
 // Format Reference:
 // https://github.com/facebook/mysql-5.6/wiki/MyRocks-record-format#memcomparable-format
 // https://haxisnake.github.io/2020/11/06/TIDB源码学习笔记-基本类型编解码方案/
-impl<'de, 'a, B: Buf + 'de> de::Deserializer<'de> for &'a mut Deserializer<B> {
+impl<'de, B: Buf + 'de> de::Deserializer<'de> for &mut Deserializer<B> {
     type Error = Error;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -586,7 +557,7 @@ impl<'de, 'a, B: Buf + 'de> de::Deserializer<'de> for &'a mut Deserializer<B> {
 
 // `VariantAccess` is provided to the `Visitor` to give it the ability to see
 // the content of the single variant that it decided to deserialize.
-impl<'de, 'a, B: Buf + 'de> VariantAccess<'de> for &'a mut Deserializer<B> {
+impl<'de, B: Buf + 'de> VariantAccess<'de> for &mut Deserializer<B> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {
@@ -615,7 +586,7 @@ impl<'de, 'a, B: Buf + 'de> VariantAccess<'de> for &'a mut Deserializer<B> {
     }
 }
 
-impl<'de, 'a, B: Buf + 'de> EnumAccess<'de> for &'a mut Deserializer<B> {
+impl<'de, B: Buf + 'de> EnumAccess<'de> for &mut Deserializer<B> {
     type Error = Error;
     type Variant = Self;
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -124,7 +124,7 @@ impl<B: BufMut> MaybeFlip<B> {
 // Format Reference:
 // https://github.com/facebook/mysql-5.6/wiki/MyRocks-record-format#memcomparable-format
 // https://haxisnake.github.io/2020/11/06/TIDB源码学习笔记-基本类型编解码方案/
-impl<'a, B: BufMut> ser::Serializer for &'a mut Serializer<B> {
+impl<B: BufMut> ser::Serializer for &mut Serializer<B> {
     type Error = Error;
     type Ok = ();
     type SerializeMap = Self;
@@ -353,7 +353,7 @@ impl<'a, B: BufMut> ser::Serializer for &'a mut Serializer<B> {
     }
 }
 
-impl<'a, B: BufMut> ser::SerializeSeq for &'a mut Serializer<B> {
+impl<B: BufMut> ser::SerializeSeq for &mut Serializer<B> {
     type Error = Error;
     type Ok = ();
 
@@ -373,7 +373,7 @@ impl<'a, B: BufMut> ser::SerializeSeq for &'a mut Serializer<B> {
     }
 }
 
-impl<'a, B: BufMut> ser::SerializeTuple for &'a mut Serializer<B> {
+impl<B: BufMut> ser::SerializeTuple for &mut Serializer<B> {
     type Error = Error;
     type Ok = ();
 
@@ -389,7 +389,7 @@ impl<'a, B: BufMut> ser::SerializeTuple for &'a mut Serializer<B> {
     }
 }
 
-impl<'a, B: BufMut> ser::SerializeTupleStruct for &'a mut Serializer<B> {
+impl<B: BufMut> ser::SerializeTupleStruct for &mut Serializer<B> {
     type Error = Error;
     type Ok = ();
 
@@ -405,7 +405,7 @@ impl<'a, B: BufMut> ser::SerializeTupleStruct for &'a mut Serializer<B> {
     }
 }
 
-impl<'a, B: BufMut> ser::SerializeTupleVariant for &'a mut Serializer<B> {
+impl<B: BufMut> ser::SerializeTupleVariant for &mut Serializer<B> {
     type Error = Error;
     type Ok = ();
 
@@ -421,7 +421,7 @@ impl<'a, B: BufMut> ser::SerializeTupleVariant for &'a mut Serializer<B> {
     }
 }
 
-impl<'a, B: BufMut> ser::SerializeMap for &'a mut Serializer<B> {
+impl<B: BufMut> ser::SerializeMap for &mut Serializer<B> {
     type Error = Error;
     type Ok = ();
 
@@ -444,7 +444,7 @@ impl<'a, B: BufMut> ser::SerializeMap for &'a mut Serializer<B> {
     }
 }
 
-impl<'a, B: BufMut> ser::SerializeStruct for &'a mut Serializer<B> {
+impl<B: BufMut> ser::SerializeStruct for &mut Serializer<B> {
     type Error = Error;
     type Ok = ();
 
@@ -460,7 +460,7 @@ impl<'a, B: BufMut> ser::SerializeStruct for &'a mut Serializer<B> {
     }
 }
 
-impl<'a, B: BufMut> ser::SerializeStructVariant for &'a mut Serializer<B> {
+impl<B: BufMut> ser::SerializeStructVariant for &mut Serializer<B> {
     type Error = Error;
     type Ok = ();
 
@@ -602,7 +602,7 @@ impl<B: BufMut> Serializer<B> {
 
         let mut byte_array = Vec::with_capacity(16);
         // Remove trailing zero.
-        while mantissa % 10 == 0 && mantissa != 0 {
+        while mantissa.is_multiple_of(10) {
             mantissa /= 10;
             digit_num -= 1;
         }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -12,75 +12,102 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use memcomparable::{from_slice, to_vec};
+use memcomparable::{from_slice, to_vec, Deserializer, Serializer};
+use serde::{Deserialize, Serialize, Serializer as _};
+
+// Helper function for generic roundtrip testing
+fn roundtrip<T: Serialize + for<'de> Deserialize<'de> + PartialEq + std::fmt::Debug>(value: &T) {
+    let serialized = to_vec(value).unwrap();
+    let deserialized: T = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, *value);
+}
+
+// Helper function for roundtrip testing with reverse/flip
+fn roundtrip_reverse<T: Serialize + for<'de> Deserialize<'de> + PartialEq + std::fmt::Debug>(
+    value: &T,
+) {
+    let mut ser = Serializer::new(vec![]);
+    ser.set_reverse(true);
+    value.serialize(&mut ser).unwrap();
+    let encoded = ser.into_inner();
+
+    let mut de = Deserializer::new(encoded.as_slice());
+    de.set_reverse(true);
+    let deserialized: T = Deserialize::deserialize(&mut de).unwrap();
+    assert_eq!(deserialized, *value);
+}
+
+// Helper function for bytes roundtrip (uses read_bytes directly)
+fn roundtrip_bytes(original: &[u8]) {
+    let original_vec = original.to_vec();
+    let serialized = to_vec(&original_vec).unwrap();
+    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+fn roundtrip_bytes_reverse(original: &[u8]) {
+    let mut ser = Serializer::new(vec![]);
+    ser.set_reverse(true);
+    ser.serialize_bytes(original).unwrap();
+    let encoded = ser.into_inner();
+
+    let mut de = Deserializer::new(encoded.as_slice());
+    de.set_reverse(true);
+    let deserialized = de.read_bytes().unwrap();
+    assert_eq!(deserialized, original);
+}
+
+// Test bytes roundtrip for both normal and reverse
+fn test_bytes_roundtrip_both(original: &[u8]) {
+    roundtrip_bytes(original);
+    roundtrip_bytes_reverse(original);
+}
 
 #[test]
 fn test_bytes_roundtrip_empty() {
-    let original: Vec<u8> = vec![];
-    let serialized = to_vec(&original).unwrap();
-    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
-    assert_eq!(deserialized, original);
+    test_bytes_roundtrip_both(&[]);
 }
 
 #[test]
 fn test_bytes_roundtrip_single_byte() {
-    let original: Vec<u8> = vec![0x42];
-    let serialized = to_vec(&original).unwrap();
-    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
-    assert_eq!(deserialized, original);
+    test_bytes_roundtrip_both(&[0x42]);
 }
 
 #[test]
 fn test_bytes_roundtrip_small() {
-    let original: Vec<u8> = vec![0x01, 0x02, 0x03];
-    let serialized = to_vec(&original).unwrap();
-    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
-    assert_eq!(deserialized, original);
+    test_bytes_roundtrip_both(&[0x01, 0x02, 0x03]);
 }
 
 #[test]
 fn test_bytes_roundtrip_exactly_one_chunk() {
     // Exactly 8 bytes (one chunk)
-    let original: Vec<u8> = (0..8).collect();
-    let serialized = to_vec(&original).unwrap();
-    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
-    assert_eq!(deserialized, original);
+    test_bytes_roundtrip_both(&(0..8).collect::<Vec<u8>>());
 }
 
 #[test]
 fn test_bytes_roundtrip_two_chunks() {
     // 10 bytes (two chunks)
-    let original: Vec<u8> = (0..10).collect();
-    let serialized = to_vec(&original).unwrap();
-    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
-    assert_eq!(deserialized, original);
+    test_bytes_roundtrip_both(&(0..10).collect::<Vec<u8>>());
 }
 
 #[test]
 fn test_bytes_roundtrip_multiple_chunks() {
     // 64 bytes (8 chunks)
-    let original: Vec<u8> = (0..64).collect();
-    let serialized = to_vec(&original).unwrap();
-    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
-    assert_eq!(deserialized, original);
+    test_bytes_roundtrip_both(&(0..64).collect::<Vec<u8>>());
 }
 
 #[test]
 fn test_bytes_roundtrip_large() {
     // 100 bytes
     let original: Vec<u8> = (0..100).map(|i| (i % 256) as u8).collect();
-    let serialized = to_vec(&original).unwrap();
-    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
-    assert_eq!(deserialized, original);
+    test_bytes_roundtrip_both(&original);
 }
 
 #[test]
 fn test_bytes_roundtrip_very_large() {
     // 1000 bytes
     let original: Vec<u8> = (0..1000).map(|i| (i % 256) as u8).collect();
-    let serialized = to_vec(&original).unwrap();
-    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
-    assert_eq!(deserialized, original);
+    test_bytes_roundtrip_both(&original);
 }
 
 #[test]
@@ -91,192 +118,149 @@ fn test_bytes_roundtrip_various_lengths() {
 
     for len in lengths {
         let original: Vec<u8> = (0..len).map(|i| (i % 256) as u8).collect();
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original, "Failed for length: {}", len);
+        roundtrip_bytes(&original);
+        roundtrip_bytes_reverse(&original);
     }
 }
 
-#[test]
-fn test_i8_roundtrip() {
-    let test_cases = vec![i8::MIN, -128, -64, -1, 0, 1, 64, 127, i8::MAX];
-
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: i8 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
+// Helper macro for numeric type roundtrip tests
+macro_rules! test_numeric_roundtrip {
+    ($name:ident, $ty:ty, $($value:expr),+) => {
+        #[test]
+        fn $name() {
+            let test_cases = vec![$($value),+];
+            for original in test_cases {
+                roundtrip(&original);
+            }
+        }
+    };
 }
 
-#[test]
-fn test_u8_roundtrip() {
-    let test_cases = vec![0u8, 1, 64, 127, 128, 255, u8::MAX];
+test_numeric_roundtrip!(
+    test_i8_roundtrip,
+    i8,
+    i8::MIN,
+    -128,
+    -64,
+    -1,
+    0,
+    1,
+    64,
+    127,
+    i8::MAX
+);
+test_numeric_roundtrip!(test_u8_roundtrip, u8, 0u8, 1, 64, 127, 128, 255, u8::MAX);
+test_numeric_roundtrip!(
+    test_i16_roundtrip,
+    i16,
+    i16::MIN,
+    -32768,
+    -16384,
+    -1,
+    0,
+    1,
+    16384,
+    32767,
+    i16::MAX
+);
+test_numeric_roundtrip!(
+    test_u16_roundtrip,
+    u16,
+    0u16,
+    1,
+    16384,
+    32767,
+    32768,
+    65535,
+    u16::MAX
+);
+test_numeric_roundtrip!(
+    test_i32_roundtrip,
+    i32,
+    i32::MIN,
+    -2147483648,
+    -1073741824,
+    -1,
+    0,
+    1,
+    1073741824,
+    2147483647,
+    i32::MAX
+);
+test_numeric_roundtrip!(
+    test_u32_roundtrip,
+    u32,
+    0u32,
+    1,
+    1073741824,
+    2147483647,
+    2147483648,
+    4294967295,
+    u32::MAX
+);
+test_numeric_roundtrip!(
+    test_i64_roundtrip,
+    i64,
+    i64::MIN,
+    -9223372036854775808,
+    -4611686018427387904,
+    -1,
+    0,
+    1,
+    4611686018427387904,
+    9223372036854775807,
+    i64::MAX
+);
+test_numeric_roundtrip!(
+    test_u64_roundtrip,
+    u64,
+    0u64,
+    1,
+    4611686018427387904,
+    9223372036854775807,
+    9223372036854775808,
+    18446744073709551615,
+    u64::MAX
+);
+test_numeric_roundtrip!(
+    test_i128_roundtrip,
+    i128,
+    i128::MIN,
+    -170141183460469231731687303715884105728,
+    -1,
+    0,
+    1,
+    170141183460469231731687303715884105727,
+    i128::MAX
+);
+test_numeric_roundtrip!(
+    test_u128_roundtrip,
+    u128,
+    0u128,
+    1,
+    170141183460469231731687303715884105727,
+    170141183460469231731687303715884105728,
+    340282366920938463463374607431768211455,
+    u128::MAX
+);
 
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: u8 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
-}
-
-#[test]
-fn test_i16_roundtrip() {
-    let test_cases = vec![i16::MIN, -32768, -16384, -1, 0, 1, 16384, 32767, i16::MAX];
-
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: i16 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
-}
-
-#[test]
-fn test_u16_roundtrip() {
-    let test_cases = vec![0u16, 1, 16384, 32767, 32768, 65535, u16::MAX];
-
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: u16 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
-}
-
-#[test]
-fn test_i32_roundtrip() {
-    let test_cases = vec![
-        i32::MIN,
-        -2147483648,
-        -1073741824,
-        -1,
-        0,
-        1,
-        1073741824,
-        2147483647,
-        i32::MAX,
-    ];
-
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: i32 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
-}
-
-#[test]
-fn test_u32_roundtrip() {
-    let test_cases = vec![
-        0u32,
-        1,
-        1073741824,
-        2147483647,
-        2147483648,
-        4294967295,
-        u32::MAX,
-    ];
-
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: u32 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
-}
-
-#[test]
-fn test_i64_roundtrip() {
-    let test_cases = vec![
-        i64::MIN,
-        -9223372036854775808,
-        -4611686018427387904,
-        -1,
-        0,
-        1,
-        4611686018427387904,
-        9223372036854775807,
-        i64::MAX,
-    ];
-
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: i64 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
-}
-
-#[test]
-fn test_u64_roundtrip() {
-    let test_cases = vec![
-        0u64,
-        1,
-        4611686018427387904,
-        9223372036854775807,
-        9223372036854775808,
-        18446744073709551615,
-        u64::MAX,
-    ];
-
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: u64 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
-}
-
-#[test]
-fn test_i128_roundtrip() {
-    let test_cases = vec![
-        i128::MIN,
-        -170141183460469231731687303715884105728,
-        -1,
-        0,
-        1,
-        170141183460469231731687303715884105727,
-        i128::MAX,
-    ];
-
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: i128 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
-}
-
-#[test]
-fn test_u128_roundtrip() {
-    let test_cases = vec![
-        0u128,
-        1,
-        170141183460469231731687303715884105727,
-        170141183460469231731687303715884105728,
-        340282366920938463463374607431768211455,
-        u128::MAX,
-    ];
-
-    for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: u128 = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
-    }
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct MixedTypes {
+    bytes: Vec<u8>,
+    i8_val: i8,
+    u8_val: u8,
+    i16_val: i16,
+    u16_val: u16,
+    i32_val: i32,
+    u32_val: u32,
+    i64_val: i64,
+    u64_val: u64,
+    i128_val: i128,
+    u128_val: u128,
 }
 
 #[test]
 fn test_mixed_types_roundtrip() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct MixedTypes {
-        bytes: Vec<u8>,
-        i8_val: i8,
-        u8_val: u8,
-        i16_val: i16,
-        u16_val: u16,
-        i32_val: i32,
-        u32_val: u32,
-        i64_val: i64,
-        u64_val: u64,
-        i128_val: i128,
-        u128_val: u128,
-    }
-
     let original = MixedTypes {
         bytes: vec![0x01, 0x02, 0x03, 0x04, 0x05],
         i8_val: -128,
@@ -291,22 +275,67 @@ fn test_mixed_types_roundtrip() {
         u128_val: u128::MAX,
     };
 
-    let serialized = to_vec(&original).unwrap();
-    let deserialized: MixedTypes = from_slice(&serialized).unwrap();
-    assert_eq!(deserialized, original);
+    roundtrip(&original);
+}
+
+#[test]
+fn test_mixed_types_roundtrip_reverse() {
+    let test_cases = vec![
+        MixedTypes {
+            bytes: vec![],
+            i8_val: 0,
+            u8_val: 0,
+            i16_val: 0,
+            u16_val: 0,
+            i32_val: 0,
+            u32_val: 0,
+            i64_val: 0,
+            u64_val: 0,
+            i128_val: 0,
+            u128_val: 0,
+        },
+        MixedTypes {
+            bytes: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+            i8_val: -128,
+            u8_val: 255,
+            i16_val: -32768,
+            u16_val: 65535,
+            i32_val: -2147483648,
+            u32_val: 4294967295,
+            i64_val: -9223372036854775808,
+            u64_val: 18446744073709551615,
+            i128_val: i128::MIN,
+            u128_val: u128::MAX,
+        },
+        MixedTypes {
+            bytes: (0..100).collect(),
+            i8_val: i8::MAX,
+            u8_val: u8::MAX,
+            i16_val: i16::MAX,
+            u16_val: u16::MAX,
+            i32_val: i32::MAX,
+            u32_val: u32::MAX,
+            i64_val: i64::MAX,
+            u64_val: u64::MAX,
+            i128_val: i128::MAX,
+            u128_val: u128::MAX,
+        },
+    ];
+
+    for original in test_cases {
+        roundtrip_reverse(&original);
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct BytesWithTypes {
+    data: Vec<u8>,
+    count: u32,
+    id: i64,
 }
 
 #[test]
 fn test_bytes_with_other_types_roundtrip() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct BytesWithTypes {
-        data: Vec<u8>,
-        count: u32,
-        id: i64,
-    }
-
     let test_cases = vec![
         BytesWithTypes {
             data: vec![],
@@ -331,25 +360,21 @@ fn test_bytes_with_other_types_roundtrip() {
     ];
 
     for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: BytesWithTypes = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
+        roundtrip(&original);
     }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct StringWithNumbers {
+    name: String,
+    count: u32,
+    flags: u8,
+    offset: i32,
+    port: u16,
 }
 
 #[test]
 fn test_string_u32_u8_i32_u16_roundtrip() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct StringWithNumbers {
-        name: String,
-        count: u32,
-        flags: u8,
-        offset: i32,
-        port: u16,
-    }
-
     let test_cases = vec![
         StringWithNumbers {
             name: "".to_string(),
@@ -382,9 +407,7 @@ fn test_string_u32_u8_i32_u16_roundtrip() {
     ];
 
     for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: StringWithNumbers = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
+        roundtrip(&original);
     }
 }
 
@@ -398,26 +421,22 @@ fn test_tuple_string_u32_u8_i32_u16_roundtrip() {
     ];
 
     for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: (String, u32, u8, i32, u16) = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
+        roundtrip(&original);
     }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct MultipleStrings {
+    first: String,
+    second: String,
+    count: u32,
+    id: u8,
+    value: i32,
+    port: u16,
 }
 
 #[test]
 fn test_multiple_strings_with_numbers_roundtrip() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct MultipleStrings {
-        first: String,
-        second: String,
-        count: u32,
-        id: u8,
-        value: i32,
-        port: u16,
-    }
-
     let test_cases = vec![
         MultipleStrings {
             first: "".to_string(),
@@ -446,28 +465,24 @@ fn test_multiple_strings_with_numbers_roundtrip() {
     ];
 
     for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: MultipleStrings = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
+        roundtrip(&original);
     }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct ComplexMixed {
+    name: String,
+    bytes: Vec<u8>,
+    count: u32,
+    flags: u8,
+    offset: i32,
+    port: u16,
+    id: i64,
+    timestamp: u64,
 }
 
 #[test]
 fn test_complex_mixed_types_roundtrip() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct ComplexMixed {
-        name: String,
-        bytes: Vec<u8>,
-        count: u32,
-        flags: u8,
-        offset: i32,
-        port: u16,
-        id: i64,
-        timestamp: u64,
-    }
-
     let test_cases = vec![
         ComplexMixed {
             name: "".to_string(),
@@ -502,30 +517,26 @@ fn test_complex_mixed_types_roundtrip() {
     ];
 
     for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: ComplexMixed = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
+        roundtrip(&original);
     }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct AllNumericTypes {
+    i8_val: i8,
+    u8_val: u8,
+    i16_val: i16,
+    u16_val: u16,
+    i32_val: i32,
+    u32_val: u32,
+    i64_val: i64,
+    u64_val: u64,
+    i128_val: i128,
+    u128_val: u128,
 }
 
 #[test]
 fn test_all_numeric_types_together_roundtrip() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct AllNumericTypes {
-        i8_val: i8,
-        u8_val: u8,
-        i16_val: i16,
-        u16_val: u16,
-        i32_val: i32,
-        u32_val: u32,
-        i64_val: i64,
-        u64_val: u64,
-        i128_val: i128,
-        u128_val: u128,
-    }
-
     let test_cases = vec![
         AllNumericTypes {
             i8_val: 0,
@@ -566,31 +577,27 @@ fn test_all_numeric_types_together_roundtrip() {
     ];
 
     for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: AllNumericTypes = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
+        roundtrip(&original);
     }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct StringsAndNumbers {
+    first: String,
+    second: String,
+    third: String,
+    i8_val: i8,
+    u8_val: u8,
+    i16_val: i16,
+    u16_val: u16,
+    i32_val: i32,
+    u32_val: u32,
+    i64_val: i64,
+    u64_val: u64,
 }
 
 #[test]
 fn test_strings_and_all_numeric_types_roundtrip() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct StringsAndNumbers {
-        first: String,
-        second: String,
-        third: String,
-        i8_val: i8,
-        u8_val: u8,
-        i16_val: i16,
-        u16_val: u16,
-        i32_val: i32,
-        u32_val: u32,
-        i64_val: i64,
-        u64_val: u64,
-    }
-
     let test_cases = vec![
         StringsAndNumbers {
             first: "".to_string(),
@@ -634,9 +641,7 @@ fn test_strings_and_all_numeric_types_roundtrip() {
     ];
 
     for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: StringsAndNumbers = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
+        roundtrip(&original);
     }
 }
 
@@ -663,31 +668,27 @@ fn test_tuple_mixed_types_roundtrip() {
     ];
 
     for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: (String, u32, u8, i32, u16, Vec<u8>) = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
+        roundtrip(&original);
     }
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Inner {
+    value: i32,
+    count: u16,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Outer {
+    name: String,
+    inner: Inner,
+    bytes: Vec<u8>,
+    id: u32,
+    flag: u8,
 }
 
 #[test]
 fn test_nested_mixed_types_roundtrip() {
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct Inner {
-        value: i32,
-        count: u16,
-    }
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct Outer {
-        name: String,
-        inner: Inner,
-        bytes: Vec<u8>,
-        id: u32,
-        flag: u8,
-    }
-
     let test_cases = vec![
         Outer {
             name: "".to_string(),
@@ -719,8 +720,22 @@ fn test_nested_mixed_types_roundtrip() {
     ];
 
     for original in test_cases {
-        let serialized = to_vec(&original).unwrap();
-        let deserialized: Outer = from_slice(&serialized).unwrap();
-        assert_eq!(deserialized, original);
+        roundtrip(&original);
+    }
+}
+
+#[test]
+fn test_string_roundtrip_reverse() {
+    let test_cases = vec![
+        "".to_string(),
+        "hello".to_string(),
+        "world".to_string(),
+        "test string with spaces".to_string(),
+        "a".repeat(100),
+        "b".repeat(1000),
+    ];
+
+    for original in test_cases {
+        roundtrip_reverse(&original);
     }
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,0 +1,726 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use memcomparable::{from_slice, to_vec};
+
+#[test]
+fn test_bytes_roundtrip_empty() {
+    let original: Vec<u8> = vec![];
+    let serialized = to_vec(&original).unwrap();
+    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn test_bytes_roundtrip_single_byte() {
+    let original: Vec<u8> = vec![0x42];
+    let serialized = to_vec(&original).unwrap();
+    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn test_bytes_roundtrip_small() {
+    let original: Vec<u8> = vec![0x01, 0x02, 0x03];
+    let serialized = to_vec(&original).unwrap();
+    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn test_bytes_roundtrip_exactly_one_chunk() {
+    // Exactly 8 bytes (one chunk)
+    let original: Vec<u8> = (0..8).collect();
+    let serialized = to_vec(&original).unwrap();
+    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn test_bytes_roundtrip_two_chunks() {
+    // 10 bytes (two chunks)
+    let original: Vec<u8> = (0..10).collect();
+    let serialized = to_vec(&original).unwrap();
+    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn test_bytes_roundtrip_multiple_chunks() {
+    // 64 bytes (8 chunks)
+    let original: Vec<u8> = (0..64).collect();
+    let serialized = to_vec(&original).unwrap();
+    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn test_bytes_roundtrip_large() {
+    // 100 bytes
+    let original: Vec<u8> = (0..100).map(|i| (i % 256) as u8).collect();
+    let serialized = to_vec(&original).unwrap();
+    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn test_bytes_roundtrip_very_large() {
+    // 1000 bytes
+    let original: Vec<u8> = (0..1000).map(|i| (i % 256) as u8).collect();
+    let serialized = to_vec(&original).unwrap();
+    let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn test_bytes_roundtrip_various_lengths() {
+    let lengths = vec![
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 32, 56, 57, 64, 65, 100, 200, 500, 1000,
+    ];
+
+    for len in lengths {
+        let original: Vec<u8> = (0..len).map(|i| (i % 256) as u8).collect();
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: Vec<u8> = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original, "Failed for length: {}", len);
+    }
+}
+
+#[test]
+fn test_i8_roundtrip() {
+    let test_cases = vec![i8::MIN, -128, -64, -1, 0, 1, 64, 127, i8::MAX];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: i8 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_u8_roundtrip() {
+    let test_cases = vec![0u8, 1, 64, 127, 128, 255, u8::MAX];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: u8 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_i16_roundtrip() {
+    let test_cases = vec![i16::MIN, -32768, -16384, -1, 0, 1, 16384, 32767, i16::MAX];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: i16 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_u16_roundtrip() {
+    let test_cases = vec![0u16, 1, 16384, 32767, 32768, 65535, u16::MAX];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: u16 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_i32_roundtrip() {
+    let test_cases = vec![
+        i32::MIN,
+        -2147483648,
+        -1073741824,
+        -1,
+        0,
+        1,
+        1073741824,
+        2147483647,
+        i32::MAX,
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: i32 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_u32_roundtrip() {
+    let test_cases = vec![
+        0u32,
+        1,
+        1073741824,
+        2147483647,
+        2147483648,
+        4294967295,
+        u32::MAX,
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: u32 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_i64_roundtrip() {
+    let test_cases = vec![
+        i64::MIN,
+        -9223372036854775808,
+        -4611686018427387904,
+        -1,
+        0,
+        1,
+        4611686018427387904,
+        9223372036854775807,
+        i64::MAX,
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: i64 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_u64_roundtrip() {
+    let test_cases = vec![
+        0u64,
+        1,
+        4611686018427387904,
+        9223372036854775807,
+        9223372036854775808,
+        18446744073709551615,
+        u64::MAX,
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: u64 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_i128_roundtrip() {
+    let test_cases = vec![
+        i128::MIN,
+        -170141183460469231731687303715884105728,
+        -1,
+        0,
+        1,
+        170141183460469231731687303715884105727,
+        i128::MAX,
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: i128 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_u128_roundtrip() {
+    let test_cases = vec![
+        0u128,
+        1,
+        170141183460469231731687303715884105727,
+        170141183460469231731687303715884105728,
+        340282366920938463463374607431768211455,
+        u128::MAX,
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: u128 = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_mixed_types_roundtrip() {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct MixedTypes {
+        bytes: Vec<u8>,
+        i8_val: i8,
+        u8_val: u8,
+        i16_val: i16,
+        u16_val: u16,
+        i32_val: i32,
+        u32_val: u32,
+        i64_val: i64,
+        u64_val: u64,
+        i128_val: i128,
+        u128_val: u128,
+    }
+
+    let original = MixedTypes {
+        bytes: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+        i8_val: -128,
+        u8_val: 255,
+        i16_val: -32768,
+        u16_val: 65535,
+        i32_val: -2147483648,
+        u32_val: 4294967295,
+        i64_val: -9223372036854775808,
+        u64_val: 18446744073709551615,
+        i128_val: i128::MIN,
+        u128_val: u128::MAX,
+    };
+
+    let serialized = to_vec(&original).unwrap();
+    let deserialized: MixedTypes = from_slice(&serialized).unwrap();
+    assert_eq!(deserialized, original);
+}
+
+#[test]
+fn test_bytes_with_other_types_roundtrip() {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct BytesWithTypes {
+        data: Vec<u8>,
+        count: u32,
+        id: i64,
+    }
+
+    let test_cases = vec![
+        BytesWithTypes {
+            data: vec![],
+            count: 0,
+            id: 0,
+        },
+        BytesWithTypes {
+            data: vec![0x42],
+            count: 1,
+            id: 1,
+        },
+        BytesWithTypes {
+            data: (0..100).collect(),
+            count: 100,
+            id: -100,
+        },
+        BytesWithTypes {
+            data: (0..1000).map(|i| (i % 256) as u8).collect(),
+            count: 1000,
+            id: 123456789,
+        },
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: BytesWithTypes = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_string_u32_u8_i32_u16_roundtrip() {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct StringWithNumbers {
+        name: String,
+        count: u32,
+        flags: u8,
+        offset: i32,
+        port: u16,
+    }
+
+    let test_cases = vec![
+        StringWithNumbers {
+            name: "".to_string(),
+            count: 0,
+            flags: 0,
+            offset: 0,
+            port: 0,
+        },
+        StringWithNumbers {
+            name: "hello".to_string(),
+            count: 42,
+            flags: 255,
+            offset: -100,
+            port: 8080,
+        },
+        StringWithNumbers {
+            name: "world".to_string(),
+            count: u32::MAX,
+            flags: u8::MAX,
+            offset: i32::MIN,
+            port: u16::MAX,
+        },
+        StringWithNumbers {
+            name: "test string with spaces".to_string(),
+            count: 123456,
+            flags: 128,
+            offset: -2147483648,
+            port: 443,
+        },
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: StringWithNumbers = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_tuple_string_u32_u8_i32_u16_roundtrip() {
+    let test_cases = vec![
+        ("".to_string(), 0u32, 0u8, 0i32, 0u16),
+        ("hello".to_string(), 42u32, 255u8, -100i32, 8080u16),
+        ("world".to_string(), u32::MAX, u8::MAX, i32::MIN, u16::MAX),
+        ("test".to_string(), 123456u32, 128u8, -2147483648i32, 443u16),
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: (String, u32, u8, i32, u16) = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_multiple_strings_with_numbers_roundtrip() {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct MultipleStrings {
+        first: String,
+        second: String,
+        count: u32,
+        id: u8,
+        value: i32,
+        port: u16,
+    }
+
+    let test_cases = vec![
+        MultipleStrings {
+            first: "".to_string(),
+            second: "".to_string(),
+            count: 0,
+            id: 0,
+            value: 0,
+            port: 0,
+        },
+        MultipleStrings {
+            first: "hello".to_string(),
+            second: "world".to_string(),
+            count: 42,
+            id: 255,
+            value: -100,
+            port: 8080,
+        },
+        MultipleStrings {
+            first: "first string".to_string(),
+            second: "second string".to_string(),
+            count: u32::MAX,
+            id: u8::MAX,
+            value: i32::MAX,
+            port: u16::MAX,
+        },
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: MultipleStrings = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_complex_mixed_types_roundtrip() {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ComplexMixed {
+        name: String,
+        bytes: Vec<u8>,
+        count: u32,
+        flags: u8,
+        offset: i32,
+        port: u16,
+        id: i64,
+        timestamp: u64,
+    }
+
+    let test_cases = vec![
+        ComplexMixed {
+            name: "".to_string(),
+            bytes: vec![],
+            count: 0,
+            flags: 0,
+            offset: 0,
+            port: 0,
+            id: 0,
+            timestamp: 0,
+        },
+        ComplexMixed {
+            name: "test".to_string(),
+            bytes: vec![0x01, 0x02, 0x03],
+            count: 42,
+            flags: 255,
+            offset: -100,
+            port: 8080,
+            id: -123456789,
+            timestamp: 1234567890,
+        },
+        ComplexMixed {
+            name: "complex test case".to_string(),
+            bytes: (0..100).collect(),
+            count: u32::MAX,
+            flags: u8::MAX,
+            offset: i32::MIN,
+            port: u16::MAX,
+            id: i64::MAX,
+            timestamp: u64::MAX,
+        },
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: ComplexMixed = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_all_numeric_types_together_roundtrip() {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct AllNumericTypes {
+        i8_val: i8,
+        u8_val: u8,
+        i16_val: i16,
+        u16_val: u16,
+        i32_val: i32,
+        u32_val: u32,
+        i64_val: i64,
+        u64_val: u64,
+        i128_val: i128,
+        u128_val: u128,
+    }
+
+    let test_cases = vec![
+        AllNumericTypes {
+            i8_val: 0,
+            u8_val: 0,
+            i16_val: 0,
+            u16_val: 0,
+            i32_val: 0,
+            u32_val: 0,
+            i64_val: 0,
+            u64_val: 0,
+            i128_val: 0,
+            u128_val: 0,
+        },
+        AllNumericTypes {
+            i8_val: -128,
+            u8_val: 255,
+            i16_val: -32768,
+            u16_val: 65535,
+            i32_val: -2147483648,
+            u32_val: 4294967295,
+            i64_val: -9223372036854775808,
+            u64_val: 18446744073709551615,
+            i128_val: i128::MIN,
+            u128_val: u128::MAX,
+        },
+        AllNumericTypes {
+            i8_val: i8::MAX,
+            u8_val: u8::MAX,
+            i16_val: i16::MAX,
+            u16_val: u16::MAX,
+            i32_val: i32::MAX,
+            u32_val: u32::MAX,
+            i64_val: i64::MAX,
+            u64_val: u64::MAX,
+            i128_val: i128::MAX,
+            u128_val: u128::MAX,
+        },
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: AllNumericTypes = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_strings_and_all_numeric_types_roundtrip() {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct StringsAndNumbers {
+        first: String,
+        second: String,
+        third: String,
+        i8_val: i8,
+        u8_val: u8,
+        i16_val: i16,
+        u16_val: u16,
+        i32_val: i32,
+        u32_val: u32,
+        i64_val: i64,
+        u64_val: u64,
+    }
+
+    let test_cases = vec![
+        StringsAndNumbers {
+            first: "".to_string(),
+            second: "".to_string(),
+            third: "".to_string(),
+            i8_val: 0,
+            u8_val: 0,
+            i16_val: 0,
+            u16_val: 0,
+            i32_val: 0,
+            u32_val: 0,
+            i64_val: 0,
+            u64_val: 0,
+        },
+        StringsAndNumbers {
+            first: "hello".to_string(),
+            second: "world".to_string(),
+            third: "test".to_string(),
+            i8_val: -128,
+            u8_val: 255,
+            i16_val: -32768,
+            u16_val: 65535,
+            i32_val: -2147483648,
+            u32_val: 4294967295,
+            i64_val: -9223372036854775808,
+            u64_val: 18446744073709551615,
+        },
+        StringsAndNumbers {
+            first: "first string".to_string(),
+            second: "second string".to_string(),
+            third: "third string".to_string(),
+            i8_val: i8::MAX,
+            u8_val: u8::MAX,
+            i16_val: i16::MAX,
+            u16_val: u16::MAX,
+            i32_val: i32::MAX,
+            u32_val: u32::MAX,
+            i64_val: i64::MAX,
+            u64_val: u64::MAX,
+        },
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: StringsAndNumbers = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_tuple_mixed_types_roundtrip() {
+    let test_cases = vec![
+        ("".to_string(), 0u32, 0u8, 0i32, 0u16, vec![] as Vec<u8>),
+        (
+            "hello".to_string(),
+            42u32,
+            255u8,
+            -100i32,
+            8080u16,
+            vec![0x01, 0x02, 0x03],
+        ),
+        (
+            "world".to_string(),
+            u32::MAX,
+            u8::MAX,
+            i32::MIN,
+            u16::MAX,
+            (0..100).collect(),
+        ),
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: (String, u32, u8, i32, u16, Vec<u8>) = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}
+
+#[test]
+fn test_nested_mixed_types_roundtrip() {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Inner {
+        value: i32,
+        count: u16,
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Outer {
+        name: String,
+        inner: Inner,
+        bytes: Vec<u8>,
+        id: u32,
+        flag: u8,
+    }
+
+    let test_cases = vec![
+        Outer {
+            name: "".to_string(),
+            inner: Inner { value: 0, count: 0 },
+            bytes: vec![],
+            id: 0,
+            flag: 0,
+        },
+        Outer {
+            name: "test".to_string(),
+            inner: Inner {
+                value: -100,
+                count: 8080,
+            },
+            bytes: vec![0x01, 0x02, 0x03],
+            id: 42,
+            flag: 255,
+        },
+        Outer {
+            name: "complex nested".to_string(),
+            inner: Inner {
+                value: i32::MAX,
+                count: u16::MAX,
+            },
+            bytes: (0..64).collect(),
+            id: u32::MAX,
+            flag: u8::MAX,
+        },
+    ];
+
+    for original in test_cases {
+        let serialized = to_vec(&original).unwrap();
+        let deserialized: Outer = from_slice(&serialized).unwrap();
+        assert_eq!(deserialized, original);
+    }
+}


### PR DESCRIPTION
# Changes

Specifically handle input than fits into one cache line, find out last non-continuation indicator and calculate the deserialized data size, we can also avoid reallocations.

Also add some roundtrip tests to assert correctness.

<img width="1248" height="727" alt="image" src="https://github.com/user-attachments/assets/a0030b6a-3ac9-4d2f-aa0c-55fbfca64e31" />

```
$ cargo bench  --bench 'serde' -- 'read_bytes' 
     Running benches/serde.rs (target/release/deps/serde-358374367734b2ff)
read_bytes/size-10      time:   [17.310 ns 17.408 ns 17.526 ns]
                        change: [-47.367% -47.052% -46.716%] (p = 0.00 < 0.05)
                        Performance has improved.

read_bytes/size-10-reverse
                        time:   [18.816 ns 19.252 ns 19.801 ns]
                        change: [-43.694% -41.106% -38.353%] (p = 0.00 < 0.05)
                        Performance has improved.

read_bytes/size-20      time:   [19.293 ns 19.390 ns 19.494 ns]
                        change: [-67.566% -67.285% -67.014%] (p = 0.00 < 0.05)
                        Performance has improved.

read_bytes/size-20-reverse
                        time:   [21.318 ns 21.457 ns 21.630 ns]
                        change: [-63.823% -63.175% -62.320%] (p = 0.00 < 0.05)
                        Performance has improved.

read_bytes/size-50      time:   [35.937 ns 36.147 ns 36.402 ns]
                        change: [-57.527% -57.064% -56.471%] (p = 0.00 < 0.05)
                        Performance has improved.

read_bytes/size-50-reverse
                        time:   [36.077 ns 36.240 ns 36.426 ns]
                        change: [-66.473% -66.063% -65.710%] (p = 0.00 < 0.05)
                        Performance has improved.

```